### PR TITLE
Use a FileStream instead of a MemoryStream

### DIFF
--- a/uSync.Migration.Pack.Seven/Controllers/uSyncPackerApiController.cs
+++ b/uSync.Migration.Pack.Seven/Controllers/uSyncPackerApiController.cs
@@ -22,39 +22,34 @@ namespace uSync.Migration.Pack.Seven.Controllers
         [HttpPost]
         public HttpResponseMessage MakePack()
         {
-
-            var filename = string.Format("migration_data_{0}.zip", DateTime.Now.ToString("yyyy_MM_dd_HHmmss"));
-            // var filename = Path.GetFileNameWithoutExtension(Path.GetRandomFileName()) + ".zip";
-
             var migrationPackService = new MigrationPackService();
             using (var stream = migrationPackService.PackExport())
             {
-                if (stream != null)
+                // If there is no stream we can exit early, something went wrong :(
+                if (stream == null) return new HttpResponseMessage(System.Net.HttpStatusCode.NotFound);
+                
+                System.IO.BinaryReader binaryReader = new System.IO.BinaryReader(stream);
+                long byteLength = new System.IO.FileInfo(stream.Name).Length;
+                var filename = Path.GetFileName(stream.Name);
+                    
+                var response = new HttpResponseMessage
                 {
-                    var response = new HttpResponseMessage
+                    Content = new ByteArrayContent(binaryReader.ReadBytes((int)byteLength))
                     {
-                        Content = new ByteArrayContent(stream.ToArray())
+                        Headers =
                         {
-                            Headers =
+                            ContentDisposition = new ContentDispositionHeaderValue("attachment")
                             {
-                                ContentDisposition = new ContentDispositionHeaderValue("attachment")
-                                {
-                                    FileName = filename
-                                },
-                                ContentType = new MediaTypeHeaderValue("application/x-zip-compressed")
-                            }
+                                FileName = filename
+                            },
+                            ContentType = new MediaTypeHeaderValue("application/x-zip-compressed")
                         }
-                    };
+                    }
+                };
 
-                    response.Headers.Add("x-filename", filename);
-                    return response;
-                }
+                response.Headers.Add("x-filename", filename);
+                return response;
             }
-
-            return new HttpResponseMessage(System.Net.HttpStatusCode.NotFound);
         }
     }
-
-
-
 }

--- a/uSync.Migration.Pack.Seven/Services/MigrationPackService.cs
+++ b/uSync.Migration.Pack.Seven/Services/MigrationPackService.cs
@@ -25,7 +25,7 @@ namespace uSync.Migration.Pack.Seven.Services
             _root = IOHelper.MapPath("~/uSync/MigrationPacks");
         }
 
-        public MemoryStream PackExport()
+        public FileStream PackExport()
         {
             var id = Path.GetFileNameWithoutExtension(Path.GetRandomFileName());
             var folder = GetExportFolder(id);
@@ -52,7 +52,6 @@ namespace uSync.Migration.Pack.Seven.Services
             CleanFolder(folder);
 
             return stream;
-          
         }
 
         /// <summary>
@@ -125,8 +124,9 @@ namespace uSync.Migration.Pack.Seven.Services
         /// <summary>
         ///  zip the folder up into return a stream 
         /// </summary>
-        private MemoryStream ZipFolder(string folder)
+        private FileStream ZipFolder(string folder)
         {
+            var filename = $"migration_data_{DateTime.Now.ToString("yyyy_MM_dd_HHmmss")}.zip";
             var folderInfo = new DirectoryInfo(folder);
             var files = folderInfo.GetFiles("*.*", SearchOption.AllDirectories).ToList();
 
@@ -141,7 +141,10 @@ namespace uSync.Migration.Pack.Seven.Services
             }
 
             stream.Seek(0, SeekOrigin.Begin);
-            return stream;
+            var fs = new FileStream(Path.Combine(_root, filename), FileMode.Create);
+            stream.WriteTo(fs);
+
+            return fs;
         }
 
         private void CleanFolder(string folder)
@@ -156,7 +159,11 @@ namespace uSync.Migration.Pack.Seven.Services
             }
         }
 
-        private string GetExportFolder(string id)
-            => Path.Combine(_root, id);
+        /// <summary>
+        /// Get the folder path for the export
+        /// </summary>
+        /// <param name="id">The unique id for the folder</param>
+        /// <returns>The full path to the folder to export to</returns>
+        private string GetExportFolder(string id) => Path.Combine(_root, id);
     }
 }


### PR DESCRIPTION
For your consideration. 

In case the download for some reason fails we don't lose the file that is generated.  On a few occasions now I have waited a really long time for the process to finish on a large site then accidentally escaped the download dialog and have lost the file and had to sit through the entire process all over again.